### PR TITLE
Fixing problem of missing user name in client

### DIFF
--- a/server/boot/routes.js
+++ b/server/boot/routes.js
@@ -17,7 +17,7 @@ module.exports = function(app) {
     app.models.User.login({
       email: email,
       password: password
-    }, function(err, user) {
+    }, function(err, token) {
       if (err) {
         res.render('index', {
           email: email,
@@ -25,9 +25,11 @@ module.exports = function(app) {
           loginFailed: true
         });
       } else {
-        res.render('projects', {
-          username: user.username,
-          accessToken: user.id
+        app.models.User.findOne({where: {id: token.userId}}, function (err, user) {
+          res.render('projects', {
+            username: user.username,
+            accessToken: token.id
+          });
         });
       }
     });


### PR DESCRIPTION
This is a better version of the previous pull request, using userId to find the user rather than email.
