### PR TITLE
fix bug for mongodb

### DIFF
--- a/common/models/team.json
+++ b/common/models/team.json
@@ -4,11 +4,11 @@
   "idInjection": true,
   "properties": {
     "ownerId": {
-      "type": "number",
+      "type": "string",
       "required": true
     },
     "memberId": {
-      "type": "number",
+      "type": "string",
       "required": true
     }
   },


### PR DESCRIPTION
Fixing bug:
loopback-example-access-control\server\boot\sample-models.js:31
        if (err) throw err;
                 ^
ValidationError: The `team` instance is not valid. Details: `memberId` can't be blank (v
alue: NaN).,ValidationError: The `team` instance is not valid. Details: `memberId` can't
be blank (value: NaN).

Caused by changing datasource from memory to mongodb.
In mongodb, type of id is string, not number.