### PR TITLE
Call mocha async callback after API response

### DIFF
--- a/test/rest_api_test.js
+++ b/test/rest_api_test.js
@@ -21,13 +21,13 @@ describe('REST API request', function() {
     require('./start-server');
     done();
   });
-  
+
   after(function(done) {
     app.removeAllListeners('started');
     app.removeAllListeners('loaded');
     done();
   });
-  
+
   it('should not allow access without access token', function(done){
     json('get', '/api/projects')
       .expect(401, done);
@@ -49,9 +49,9 @@ describe('REST API request', function() {
             var projects = res.body;
             assert(typeof res.body === 'object');
             assert(res.body.balance);
-            assert.equal(res.body.balance, 100); 
+            assert.equal(res.body.balance, 100);
+            done();
           });
-        done();
       });
   });
 
@@ -72,8 +72,8 @@ describe('REST API request', function() {
             var projects = res.body;
             assert(Array.isArray(res.body));
             assert.equal(res.body.length, 2);
+            done();
           });
-        done();
       });
   });
 
@@ -83,12 +83,12 @@ describe('REST API request', function() {
             id: 2,
             amount: 10
           })
-          .expect(200, function(err, res){            
+          .expect(200, function(err, res){
             assert(typeof res.body === 'object');
             assert(res.body.success);
             assert.equal(res.body.success, true);
+            done();
           });
-        done();
   });
 });
 


### PR DESCRIPTION
ex: changing ```assert.equal(res.body.length, 2);``` to ```assert.equal(res.body.length, 3);``` will not trigger test fail because done() is called before assert