### PR TITLE
User - Team relation definition is misleading

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Define three remote methods in [`project.js`](https://github.com/strongloop/loop
       - Custom foreign key: `ownerId`
       - Require a through model: No
     - `team`
-      - Property name for the relation: `teams`
+      - Property name for the relation: `teamMembers`
       - Custom foreign key: `ownerId`
       - Require a through model: No
 - `team`


### PR DESCRIPTION
As the Team entity has only ownerId and memberId properties (only foreign keys), it is impossible to the User to have more than one Team. So User has many teamMembers, not many Teams. 

Current definition can lead to misunderstanding of Role Resolver that finds _teams_ where 
- team owner is project owner
- current user is team member
  which suggests that current user can be member of any project owner teams (but there is only one)

I propose to change it to make people better understand the logic behind that. Code related to that relation needs to be updated too.
