### PR TITLE
Use datasource cloudant

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-# loopback-example-access-control
+# loopback-example-access-control(use datasource cloudant)
 
 ```
 $ git clone https://github.com/strongloop/loopback-example-access-control
 $ cd loopback-example-access-control
 $ npm install
+Change credential of `mycloudant` in server/datasources.json to your cloudant credential
 $ node .
 ```
 
@@ -48,19 +49,31 @@ $ lb app loopback-example-access-control
 ... # follow the prompts
 $ cd loopback-example-access-control
 ```
+### Add the datasource
+- Name: `mycloudant`
+  - datasource: `cloudant`
+  - url: `your_cloudant_url`
+  - database: `your_cloudant_database`
+  - username: `your_cloudant_username`
+  - password: `your_cloudant_password`
+
+```
+$ lb datasource
+... # follow the prompts to provide your credential
+```
 
 ### Add the models
 
 #### Model information
 - Name: `user`
-  - Datasource: `db (memory)`
+  - Datasource: `mycloudant`
   - Base class: `User`
   - Expose via REST: `No`
   - Custom plural form: *Leave blank*
   - Properties
     - *None*
 - Name: `team`
-  - Datasource: `db (memory)`
+  - Datasource: `mycloudant`
   - Base class: `PersistedModel`
   - Expose via REST: `No`
   - Custom plural form: *Leave blank*
@@ -72,7 +85,7 @@ $ cd loopback-example-access-control
       - Number
       - Required
 - Name: `project`
-  - Datasource: `db (memory)`
+  - Datasource: `mycloudant`
   - Base class: `PersistedModel`
   - Expose via REST: `Yes`
   - Custom plural form: *Leave blank*
@@ -128,7 +141,7 @@ Define three remote methods in [`project.js`](https://github.com/strongloop/loop
 
 ### Add model instances
 
-Create a boot script named [`sample-models.js`](https://github.com/strongloop/loopback-example-access-control/blob/master/server/boot/sample-models.js).
+Create a boot script named [`sample-models.js`](https://github.com/strongloop/loopback-example-access-control/blob/use-datasource-cloudant/server/boot/sample-models.js).
 
 This script does the following:
 
@@ -177,7 +190,7 @@ In this directory, create [`index.ejs`](https://github.com/strongloop/loopback-e
 
 ### Create a role resolver
 
-Create [`role-resolver.js`](https://github.com/strongloop/loopback-example-access-control/blob/master/server/boot/role-resolver.js).
+Create [`role-resolver.js`](https://github.com/strongloop/loopback-example-access-control/blob/use-datasource-cloudant/server/boot/role-resolver.js).
 
 > This file checks if the context relates to the project model and if the
 > request maps to a user. If these two requirements are not met, the request is

--- a/README.md
+++ b/README.md
@@ -105,7 +105,10 @@ $ lb model user
 ... # follow the prompts, repeat for `team` and `project`
 ```
 
-**Important** `Role`, `RoleMapping`, `ACL`, `AccessToken`, `User` are attached to `db` by default, but since this branch demos access control with cloudant datasource, please go to `server/model-config.json` and manually change their datasource to `mycloudant`.
+> **Important:** `Role`, `RoleMapping`, `ACL`, `AccessToken`, `User` are
+> attached to `db` by default, but since this branch demos access control with
+> cloudant datasource, please go to `server/model-config.json` and manually
+> change their datasource to `mycloudant`.
 
 ### Define the remote methods
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 $ git clone https://github.com/strongloop/loopback-example-access-control
 $ cd loopback-example-access-control
 $ npm install
-Change credential of `mycloudant` in server/datasources.json to your cloudant credential
+Manually change credential of `mycloudant` in server/datasources.json to your cloudant credential
 $ node .
 ```
 
@@ -104,6 +104,8 @@ $ lb datasource
 $ lb model user
 ... # follow the prompts, repeat for `team` and `project`
 ```
+
+**Important** `Role`, `RoleMapping`, `ACL`, `AccessToken`, `User` are attached to `db` by default, but since this branch demos access control with cloudant datasource, please go to `server/model-config.json` and manually change their datasource to `mycloudant`.
 
 ### Define the remote methods
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 $ git clone https://github.com/strongloop/loopback-example-access-control
 $ cd loopback-example-access-control
 $ npm install
-Manually change credential of `mycloudant` in server/datasources.json to your cloudant credential
+Go to server/datasources.json and change the credential of `mycloudant` to your cloudant credential.
 $ node .
 ```
 
@@ -50,6 +50,11 @@ $ lb app loopback-example-access-control
 $ cd loopback-example-access-control
 ```
 ### Add the datasource
+
+Cloudant credential requires a combination of either `url` & `database`, or `username` & `password` & `database`. The following example includes all of them, but you don't need to provide all, and `url` will override `username` & `password` if provided. 
+
+For details of how to set the config, please check https://github.com/strongloop/loopback-connector-cloudant#configuration
+
 - Name: `mycloudant`
   - datasource: `cloudant`
   - url: `your_cloudant_url`

--- a/common/models/project.json
+++ b/common/models/project.json
@@ -61,5 +61,5 @@
       "property": "withdraw"
     }
   ],
-  "methods": []
+  "methods": {}
 }

--- a/common/models/team.json
+++ b/common/models/team.json
@@ -21,5 +21,5 @@
     }
   },
   "acls": [],
-  "methods": []
+  "methods": {}
 }

--- a/common/models/user.json
+++ b/common/models/user.json
@@ -2,10 +2,13 @@
   "name": "user",
   "base": "User",
   "idInjection": true,
+  "options": {
+    "validateUpsert": true
+  },
   "properties": {},
   "validations": [],
   "relations": {
-    "projects": {
+     "projects": {
       "type": "hasMany",
       "model": "project",
       "foreignKey": "ownerId"
@@ -17,5 +20,5 @@
     }
   },
   "acls": [],
-  "methods": []
+  "methods": {}
 }

--- a/common/models/user.json
+++ b/common/models/user.json
@@ -8,7 +8,7 @@
   "properties": {},
   "validations": [],
   "relations": {
-     "projects": {
+    "projects": {
       "type": "hasMany",
       "model": "project",
       "foreignKey": "ownerId"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "cors": "^2.8.1",
     "loopback": "^3.0.0",
     "loopback-boot": "^2.4.0",
+    "loopback-connector-cloudant": "^2.0.0",
     "serve-favicon": "^2.0.1",
     "strong-error-handler": "^1.1.1",
     "supertest": "^1.1.0"

--- a/server/boot/role-resolver.js
+++ b/server/boot/role-resolver.js
@@ -47,6 +47,6 @@ module.exports = function(app, done) {
       });
     });
     done();
-  })
+  });
   
 };

--- a/server/boot/role-resolver.js
+++ b/server/boot/role-resolver.js
@@ -3,44 +3,50 @@
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
 
-module.exports = function(app) {
+module.exports = function(app, done) {
   var Role = app.models.Role;
+  var db = app.datasources.mycloudant;
 
-  Role.registerResolver('teamMember', function(role, context, cb) {
-    function reject() {
-      process.nextTick(function() {
-        cb(null, false);
-      });
-    }
+  db.automigrate(function(err) {
+    if (err) return done(err);
+    Role.registerResolver('teamMember', function(role, context, cb) {
+      function reject() {
+        process.nextTick(function() {
+          cb(null, false);
+        });
+      }
 
-    // if the target model is not project
-    if (context.modelName !== 'project') {
-      return reject();
-    }
-
-    // do not allow anonymous users
-    var userId = context.accessToken.userId;
-    if (!userId) {
-      return reject();
-    }
-
-    // check if userId is in team table for the given project id
-    context.model.findById(context.modelId, function(err, project) {
-      if (err || !project)
+      // if the target model is not project
+      if (context.modelName !== 'project') {
         return reject();
+      }
 
-      var Team = app.models.Team;
-      Team.count({
-        ownerId: project.ownerId,
-        memberId: userId
-      }, function(err, count) {
-        if (err) {
-          console.log(err);
-          return cb(null, false);
-        }
+      // do not allow anonymous users
+      var userId = context.accessToken.userId;
+      if (!userId) {
+        return reject();
+      }
 
-        cb(null, count > 0); // true = is a team member
+      // check if userId is in team table for the given project id
+      context.model.findById(context.modelId, function(err, project) {
+        if (err || !project)
+          return reject();
+
+        var Team = app.models.Team;
+        Team.count({
+          ownerId: project.ownerId,
+          memberId: userId
+        }, function(err, count) {
+          if (err) {
+            console.log(err);
+            cb(null, false);
+          }
+
+          cb(null, count > 0); // true = is a team member
+        });
       });
     });
-  });
+    done();
+  })
+  
 };

--- a/server/boot/role-resolver.js
+++ b/server/boot/role-resolver.js
@@ -7,46 +7,48 @@ module.exports = function(app, done) {
   var Role = app.models.Role;
   var db = app.datasources.mycloudant;
 
-  db.automigrate(function(err) {
-    if (err) return done(err);
-    Role.registerResolver('teamMember', function(role, context, cb) {
-      function reject() {
-        process.nextTick(function() {
-          cb(null, false);
-        });
-      }
-
-      // if the target model is not project
-      if (context.modelName !== 'project') {
-        return reject();
-      }
-
-      // do not allow anonymous users
-      var userId = context.accessToken.userId;
-      if (!userId) {
-        return reject();
-      }
-
-      // check if userId is in team table for the given project id
-      context.model.findById(context.modelId, function(err, project) {
-        if (err || !project)
-          return reject();
-
-        var Team = app.models.Team;
-        Team.count({
-          ownerId: project.ownerId,
-          memberId: userId
-        }, function(err, count) {
-          if (err) {
-            console.log(err);
+  db.once('connected', function(err) {
+    db.automigrate(function(err) {
+      if (err) return done(err);
+      Role.registerResolver('teamMember', function(role, context, cb) {
+        function reject() {
+          process.nextTick(function() {
             cb(null, false);
-          }
+          });
+        }
 
-          cb(null, count > 0); // true = is a team member
+        // if the target model is not project
+        if (context.modelName !== 'project') {
+          return reject();
+        }
+
+        // do not allow anonymous users
+        var userId = context.accessToken.userId;
+        if (!userId) {
+          return reject();
+        }
+
+        // check if userId is in team table for the given project id
+        context.model.findById(context.modelId, function(err, project) {
+          if (err || !project)
+            return reject();
+
+          var Team = app.models.Team;
+          Team.count({
+            ownerId: project.ownerId,
+            memberId: userId
+          }, function(err, count) {
+            if (err) {
+              console.log(err);
+              cb(null, false);
+            }
+
+            cb(null, count > 0); // true = is a team member
+          });
         });
       });
+      done();
     });
-    done();
   });
   
 };

--- a/server/datasources.json
+++ b/server/datasources.json
@@ -2,5 +2,14 @@
   "db": {
     "name": "db",
     "connector": "memory"
+  },
+  "mycloudant": {
+    "url": "your_cloudant_server_url",
+    "database": "dev",
+    "username": "",
+    "password": "",
+    "name": "mycloudant",
+    "modelIndex": "",
+    "connector": "cloudant"
   }
 }

--- a/server/datasources.json
+++ b/server/datasources.json
@@ -5,7 +5,7 @@
   },
   "mycloudant": {
     "url": "your_cloudant_server_url",
-    "database": "dev",
+    "database": "your_cloudant_database",
     "username": "",
     "password": "",
     "name": "mycloudant",

--- a/server/middleware.json
+++ b/server/middleware.json
@@ -12,19 +12,17 @@
       }
     }
   },
-  "session": {
-  },
-  "auth": {
-  },
-  "parse": {
-  },
+  "session": {},
+  "auth": {},
+  "parse": {},
   "routes": {
     "loopback#rest": {
-      "paths": ["${restApiRoot}"]
+      "paths": [
+        "${restApiRoot}"
+      ]
     }
   },
-  "files": {
-  },
+  "files": {},
   "final": {
     "loopback#urlNotFound": {}
   },

--- a/server/model-config.json
+++ b/server/model-config.json
@@ -8,28 +8,24 @@
     ]
   },
   "User": {
-    "dataSource": "db",
+    "dataSource": "mycloudant",
     "public": false
   },
   "AccessToken": {
-    "dataSource": "db",
+    "dataSource": "mycloudant",
     "public": false
   },
   "ACL": {
-    "dataSource": "db",
+    "dataSource": "mycloudant",
     "public": false
   },
   "RoleMapping": {
-    "dataSource": "db",
+    "dataSource": "mycloudant",
     "public": false
   },
   "Role": {
-    "dataSource": "db",
+    "dataSource": "mycloudant",
     "public": false
-  },
-  "user": {
-    "dataSource": "db",
-    "public": true
   },
   "team": {
     "dataSource": "db",
@@ -37,6 +33,10 @@
   },
   "project": {
     "dataSource": "db",
+    "public": true
+  },
+  "user": {
+    "dataSource": "mycloudant",
     "public": true
   }
 }

--- a/server/model-config.json
+++ b/server/model-config.json
@@ -28,11 +28,11 @@
     "public": false
   },
   "team": {
-    "dataSource": "db",
+    "dataSource": "mycloudant",
     "public": false
   },
   "project": {
-    "dataSource": "db",
+    "dataSource": "mycloudant",
     "public": true
   },
   "user": {


### PR DESCRIPTION
### Description
#### Related issues
Connect to strongloop-internal/scrum-apex#155

I create a new branch `use-datasource-cloudant` to demo access control(Role and User) with relevant models attached to cloudant datasource.

There are some syntax changes in this PR because master is still using an old version of loopback. The three main changes are:

- server/datasources.json
    - Add cloudant datasource
- server/model-config.json
    - Attach relevant models to cloudant.
- server/boot/role-resolver.js
    - automigrate models attached to cloudant datasource    
    - Switch to async boot script, since other scripts need to wait until automigrating models to cloudant datasource done.

And udpated the doc as well.

