### PR TITLE
Remove "," from tuple definition of remote method

### DIFF
--- a/common/models/project.js
+++ b/common/models/project.js
@@ -31,7 +31,7 @@ module.exports = function(Project) {
   Project.remoteMethod('donate', {
     accepts: [
       {arg: 'id', type: 'number'},
-      {arg: 'amount', type: 'number'},
+      {arg: 'amount', type: 'number'}
     ],
     returns: {arg: 'success', type: 'boolean'},
     http: {path:'/donate', verb: 'post'}
@@ -52,7 +52,7 @@ module.exports = function(Project) {
   Project.remoteMethod('withdraw', {
     accepts: [
       {arg: 'id', type: 'number'},
-      {arg: 'amount', type: 'number'},
+      {arg: 'amount', type: 'number'}
     ],
     returns: {arg: 'success', type: 'boolean'},
     http: {path:'/withdraw', verb: 'post'}


### PR DESCRIPTION
…draw.

Will cause unnecessary token error

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
